### PR TITLE
Fix Mean Flux

### DIFF
--- a/radionets/evaluation/plotting.py
+++ b/radionets/evaluation/plotting.py
@@ -19,7 +19,6 @@ from radionets.evaluation.blob_detection import calc_blobs
 from radionets.evaluation.contour import compute_area_difference
 from pytorch_msssim import ms_ssim
 from matplotlib.patches import Rectangle
-from matplotlib.colors import LogNorm
 from matplotlib import cm
 from matplotlib.colors import ListedColormap
 import matplotlib as mpl

--- a/radionets/evaluation/train_inspection.py
+++ b/radionets/evaluation/train_inspection.py
@@ -395,10 +395,10 @@ def evaluate_mean_diff(conf):
             flux_pred, flux_truth = crop_first_component(
                 pred, truth, blobs_truth[0], out_path
             )
-            vals.extend([1 - flux_truth.mean() / flux_pred.mean()])
+            vals.extend([(flux_pred.mean() - flux_truth.mean()) / flux_truth.mean()])
 
     click.echo("\nCreating mean_diff histogram.\n")
-    vals = torch.tensor(vals)
+    vals = torch.tensor(vals) * 100
     histogram_mean_diff(
         vals, out_path, plot_format=conf["format"],
     )


### PR DESCRIPTION
The mean flux was not calculated in percent and was normalized to the estimated value, which is not optimal. This should be fixed by `flux_pred.mean() - flux_truth.mean()) / flux_truth.mean()` and multiplying with 100.