### PR TITLE
Replace .format with f strings

### DIFF
--- a/radionets/dl_framework/inspection.py
+++ b/radionets/dl_framework/inspection.py
@@ -21,7 +21,8 @@ def plot_loss(learn, model_path, output_format="pdf"):
     save_path = model_path.with_suffix("")
     print(f"\nPlotting Loss for: {model_path.stem}\n")
     logscale = learn.avg_loss.plot_loss()
-    plt.title(r"{}".format(str(model_path.stem).replace("_", " ")))
+    title = str(model_path.stem).replace("_", " ")
+    plt.title(fr"{title}")
     if logscale:
         plt.yscale("log")
     plt.savefig(

--- a/radionets/dl_framework/logger.py
+++ b/radionets/dl_framework/logger.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 
 file_dir = Path(__file__).parent.resolve()
-file_name = file_dir/"values.yaml"
+file_name = file_dir / "values.yaml"
 if file_name.exists():
     stream = open(file_name, 'r')
     values = yaml.load(stream, Loader=yaml.FullLoader)
@@ -47,7 +47,7 @@ class LogstashFormatter(Formatter):
         to_zone = tz.gettz("Europe/Berlin")
         from_zone = tz.gettz("UTC")
 
-        # transform to whished timezone
+        # transform to desired timezone
         # taken from
         # https://stackoverflow.com/questions/4770297/convert-utc-datetime-string-to-local-datetime
         t = t.replace(tzinfo=from_zone)

--- a/radionets/dl_framework/model.py
+++ b/radionets/dl_framework/model.py
@@ -261,7 +261,7 @@ def load_pre_model(learn, pre_path, visualize=False):
     :param lr_find:     bool which is True if lr_find is used
     """
     name_pretrained = Path(pre_path).stem
-    print("\nLoad pretrained model: {}\n".format(name_pretrained))
+    print(f"\nLoad pretrained model: {name_pretrained}\n")
     if torch.cuda.is_available():
         checkpoint = torch.load(pre_path)
     else:

--- a/radionets/dl_training/utils.py
+++ b/radionets/dl_training/utils.py
@@ -78,7 +78,7 @@ def pop_interrupt(learn, train_conf):
     if click.confirm("KeyboardInterrupt, do you want to save the model?", abort=False):
         model_path = train_conf["model_path"]
         # save model
-        print("Saving the model after epoch {}".format(learn.epoch))
+        print(f"Saving the model after epoch {learn.epoch}")
         save_model(learn, model_path)
 
         # plot loss
@@ -88,7 +88,7 @@ def pop_interrupt(learn, train_conf):
         if train_conf["inspection"]:
             create_inspection_plots(learn, train_conf)
     else:
-        print("Stopping after epoch {}".format(learn.epoch))
+        print(f"Stopping after epoch {learn.epoch}")
     sys.exit(1)
 
 

--- a/radionets/evaluation/plotting.py
+++ b/radionets/evaluation/plotting.py
@@ -361,7 +361,7 @@ def visualize_source_reconstruction(
         m_pred * x_space + n_pred,
         "w-",
         alpha=0.5,
-        label=fr"$\alpha = {np.round(alpha_pred[0], 3)}\,$deg",
+        label=fr"$\alpha = {alpha_pred[0]:.2f}\,$deg",
     )
     im1 = ax1.imshow(ifft_pred, vmax=ifft_truth.max(), cmap="inferno")
     ax2.plot(
@@ -369,7 +369,7 @@ def visualize_source_reconstruction(
         m_truth * x_space + n_truth,
         "w-",
         alpha=0.5,
-        label=fr"$\alpha = {np.round(alpha_truth[0], 3)}\,$deg",
+        label=fr"$\alpha = {alpha_truth[0]:.2f}\,$deg",
     )
     im2 = ax2.imshow(ifft_truth, cmap="inferno")
 
@@ -465,8 +465,8 @@ def plot_contour(ifft_pred, ifft_truth, out_path, i, plot_format="png"):
 def histogram_jet_angles(alpha_truth, alpha_pred, out_path, plot_format="png"):
     dif = (alpha_pred - alpha_truth).numpy()
 
-    mean = np.round(np.mean(dif), 3)
-    std = np.round(np.std(dif, ddof=1), 3)
+    mean = np.mean(dif)
+    std = np.std(dif, ddof=1)
 
     fig, (ax1, ax2) = plt.subplots(2, 1, figsize=(6, 8))
     ax1.hist(
@@ -482,7 +482,7 @@ def histogram_jet_angles(alpha_truth, alpha_pred, out_path, plot_format="png"):
 
     extra_1 = Rectangle((0, 0), 1, 1, fc="w", fill=False, edgecolor="none", linewidth=0)
     extra_2 = Rectangle((0, 0), 1, 1, fc="w", fill=False, edgecolor="none", linewidth=0)
-    ax1.legend([extra_1, extra_2], ("Mean: {}".format(mean), "Std: {}".format(std)))
+    ax1.legend([extra_1, extra_2], (f"Mean: {mean:.2f}", f"Std: {std:.2f}"))
 
     ax2.hist(
         dif[(dif > -10) & (dif < 10)],
@@ -626,8 +626,8 @@ def histogram_ms_ssim(msssim, out_path, plot_format="png"):
 
 def histogram_mean_diff(vals, out_path, plot_format="png"):
     vals = vals.numpy()
-    mean = np.round(np.mean(vals), 3)
-    std = np.round(np.std(vals, ddof=1), 3)
+    mean = np.mean(vals)
+    std = np.std(vals, ddof=1)
     fig, (ax1) = plt.subplots(1, figsize=(6, 4))
     ax1.hist(
         vals,
@@ -641,7 +641,7 @@ def histogram_mean_diff(vals, out_path, plot_format="png"):
     ax1.set_ylabel("Number of sources")
     extra_1 = Rectangle((0, 0), 1, 1, fc="w", fill=False, edgecolor="none", linewidth=0)
     extra_2 = Rectangle((0, 0), 1, 1, fc="w", fill=False, edgecolor="none", linewidth=0)
-    ax1.legend([extra_1, extra_2], ("Mean: {}".format(mean), "Std: {}".format(std)))
+    ax1.legend([extra_1, extra_2], (f"Mean: {mean:.2f}", f"Std: {std:.2f}"))
 
     fig.tight_layout()
 
@@ -651,8 +651,8 @@ def histogram_mean_diff(vals, out_path, plot_format="png"):
 
 def histogram_area(vals, out_path, plot_format="png"):
     vals = vals.numpy()
-    mean = np.round(np.mean(vals), 3)
-    std = np.round(np.std(vals, ddof=1), 3)
+    mean = np.mean(vals)
+    std = np.std(vals, ddof=1)
     fig, (ax1) = plt.subplots(1, figsize=(6, 4))
     ax1.hist(
         vals,
@@ -667,7 +667,7 @@ def histogram_area(vals, out_path, plot_format="png"):
 
     extra_1 = Rectangle((0, 0), 1, 1, fc="w", fill=False, edgecolor="none", linewidth=0)
     extra_2 = Rectangle((0, 0), 1, 1, fc="w", fill=False, edgecolor="none", linewidth=0)
-    ax1.legend([extra_1, extra_2], ("Mean: {}".format(mean), "Std: {}".format(std)))
+    ax1.legend([extra_1, extra_2], (f"Mean: {mean:.2f}", f"Std: {std:.2f}"))
 
     fig.tight_layout()
 
@@ -680,10 +680,10 @@ def hist_point(vals, mask, out_path, plot_format="png"):
     min_all = vals.min()
     bins = np.arange(min_all, 100 + binwidth, binwidth)
 
-    mean_point = np.round(np.mean(vals[mask]), 3)
-    std_point = np.round(np.std(vals[mask], ddof=1), 3)
-    mean_extent = np.round(np.mean(vals[~mask]), 3)
-    std_extent = np.round(np.std(vals[~mask], ddof=1), 3)
+    mean_point = np.mean(vals[mask])
+    std_point = np.std(vals[mask], ddof=1)
+    mean_extent = np.mean(vals[~mask])
+    std_extent = np.std(vals[~mask], ddof=1)
     fig, (ax1) = plt.subplots(1, figsize=(6, 4))
     ax1.hist(
         vals[mask],
@@ -714,8 +714,8 @@ def hist_point(vals, mask, out_path, plot_format="png"):
     ax1.legend(
         [extra_1, extra_2],
         [
-            fr"Point: $({mean_point}\pm{std_point})\,\%$",
-            fr"Extended: $({mean_extent}\pm{std_extent})\,\%$",
+            fr"Point: $({mean_point:.2f}\pm{std_point:.2f})\,\%$",
+            fr"Extended: $({mean_extent:.2f}\pm{std_extent:.2f})\,\%$",
         ],
     )
     outpath = str(out_path) + f"/hist_point.{plot_format}"

--- a/radionets/evaluation/plotting.py
+++ b/radionets/evaluation/plotting.py
@@ -441,7 +441,7 @@ def plot_contour(ifft_pred, ifft_truth, out_path, i, plot_format="png"):
     im2 = ax2.imshow(ifft_truth)
     CS2 = ax2.contour(ifft_truth, levels=levels, colors=colors)
     diff = np.round(compute_area_ratio(CS1, CS2), 2)
-    make_axes_nice(fig, ax2, im2, "Truth, ratio: {}".format(diff))
+    make_axes_nice(fig, ax2, im2, f"Truth, ratio: {diff}")
     outpath = str(out_path) + f"/contour_{diff}_{i}.{plot_format}"
 
     # Assign labels for the levels and save them for the legend

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -281,7 +281,7 @@ class TestEvaluation:
         assert flux_pred.all() > 0
         assert flux_truth.all() > 0
 
-    @pytest.mark.xfail
+    # @pytest.mark.xfail
     def test_evaluation(self):
         import shutil
         import os

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -281,7 +281,7 @@ class TestEvaluation:
         assert flux_pred.all() > 0
         assert flux_truth.all() > 0
 
-    # @pytest.mark.xfail
+    @pytest.mark.xfail
     def test_evaluation(self):
         import shutil
         import os

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -82,11 +82,9 @@ def test_save_model():
                             ):
                                 check(value4)
                             else:
-                                assert False, "Unrecognised type {} {}".format(
-                                    key4, type(value4)
-                                )
+                                assert False, f"Unrecognised type {key4} {type(value4)}"
                 else:
-                    assert False, "Unrecognised type {} {}".format(key2, type(value2))
+                    assert False, f"Unrecognised type {key2} {type(value2)}"
         elif isinstance(value, list):
             for ele2 in value:
                 if isinstance(ele2, (int, float)) or torch.is_tensor(ele2):
@@ -96,9 +94,9 @@ def test_save_model():
                         if isinstance(ele3, (float)):
                             check(ele3)
                         else:
-                            assert False, "Unrecognised type {}".format(type(ele3))
+                            assert False, f"Unrecognised type {type(ele3)}"
                 else:
-                    assert False, "Unrecognised type {}".format(type(ele2))
+                    assert False, f"Unrecognised type {type(ele2)}"
         else:
             check(value)
 


### PR DESCRIPTION
Replaced `.format` with f strings. Also removed unnecessary `np.round` usage in `plotting.py` and used floating-point arithmetic to ensure a fixed number of decimal places. See also #104 