### PR TITLE
Add angle visualization

### DIFF
--- a/radionets/evaluation/jet_angle.py
+++ b/radionets/evaluation/jet_angle.py
@@ -111,8 +111,8 @@ def calc_jet_angle(image):
             maxima.extend([a])
 
     vals = torch.tensor(maxima)
-    x_mid = vals[:, 0]
-    y_mid = vals[:, 1]
+    x_mid = 32
+    y_mid = 32
 
     m = torch.tan(pi / 2 - alpha_pca)
     n = y_mid - m * x_mid

--- a/radionets/evaluation/plotting.py
+++ b/radionets/evaluation/plotting.py
@@ -365,14 +365,12 @@ def visualize_source_reconstruction(
         alpha=0.5,
         label=fr"$\alpha = {np.round(alpha_pred[0], 3)}\,$deg",
     )
-    ax1.axvline(32, 0, 1, linestyle="--", color="red")
-    if alpha_pred < 0:
-        theta1 = 0
-        theta2 = -alpha_pred.numpy()[0]
-    else:
-        theta1 = -alpha_pred.numpy()[0]
-        theta2 = 0
-    ax1.add_patch(Arc([32, 32], 50, 50, 90, theta1, theta2, color="blue",))
+    ax1.axvline(32, 0, 1, linestyle="--", color="green")
+
+    theta1 = min(0, -alpha_pred.numpy()[0])
+    theta2 = max(0, -alpha_pred.numpy()[0])
+    ax1.add_patch(Arc([32, 32], 50, 50, 90, theta1, theta2, color="green",))
+
     im1 = ax1.imshow(ifft_pred, vmax=ifft_truth.max(), cmap="inferno")
     ax2.plot(
         x_space,
@@ -381,14 +379,12 @@ def visualize_source_reconstruction(
         alpha=0.5,
         label=fr"$\alpha = {np.round(alpha_truth[0], 3)}\,$deg",
     )
-    ax2.axvline(32, 0, 1, linestyle="--", color="red")
-    if alpha_truth < 0:
-        theta1 = 0
-        theta2 = -alpha_truth.numpy()[0]
-    else:
-        theta1 = -alpha_truth.numpy()[0]
-        theta2 = 0
-    ax2.add_patch(Arc([32, 32], 50, 50, 90, theta1, theta2, color="blue",))
+    ax2.axvline(32, 0, 1, linestyle="--", color="green")
+
+    theta1 = min(0, -alpha_truth.numpy()[0])
+    theta2 = max(0, -alpha_truth.numpy()[0])
+    ax2.add_patch(Arc([32, 32], 50, 50, 90, theta1, theta2, color="green",))
+
     im2 = ax2.imshow(ifft_truth, cmap="inferno")
 
     a = check_vmin_vmax(ifft_pred - ifft_truth)

--- a/radionets/evaluation/plotting.py
+++ b/radionets/evaluation/plotting.py
@@ -350,9 +350,11 @@ def visualize_source_reconstruction(
     msssim=False,
     plot_format="png",
 ):
+    from matplotlib.patches import Arc
     m_truth, n_truth, alpha_truth = calc_jet_angle(ifft_truth)
     m_pred, n_pred, alpha_pred = calc_jet_angle(ifft_pred)
     x_space = torch.arange(0, 511, 1)
+    # print(m_truth, n_truth, alpha_truth.numpy())
 
     # plt.style.use("./paper_large_3.rc")
     fig, (ax1, ax2, ax3) = plt.subplots(1, 3, figsize=(16, 10), sharey=True)
@@ -363,6 +365,14 @@ def visualize_source_reconstruction(
         alpha=0.5,
         label=fr"$\alpha = {np.round(alpha_pred[0], 3)}\,$deg",
     )
+    ax1.axvline(32, 0, 1, linestyle="--", color="red")
+    if alpha_pred < 0:
+        theta1 = 0
+        theta2 = -alpha_pred.numpy()[0]
+    else:
+        theta1 = -alpha_pred.numpy()[0]
+        theta2 = 0
+    ax1.add_patch(Arc([32, 32], 50, 50, 90, theta1, theta2, color="blue",))
     im1 = ax1.imshow(ifft_pred, vmax=ifft_truth.max(), cmap="inferno")
     ax2.plot(
         x_space,
@@ -371,6 +381,14 @@ def visualize_source_reconstruction(
         alpha=0.5,
         label=fr"$\alpha = {np.round(alpha_truth[0], 3)}\,$deg",
     )
+    ax2.axvline(32, 0, 1, linestyle="--", color="red")
+    if alpha_truth < 0:
+        theta1 = 0
+        theta2 = -alpha_truth.numpy()[0]
+    else:
+        theta1 = -alpha_truth.numpy()[0]
+        theta2 = 0
+    ax2.add_patch(Arc([32, 32], 50, 50, 90, theta1, theta2, color="blue",))
     im2 = ax2.imshow(ifft_truth, cmap="inferno")
 
     a = check_vmin_vmax(ifft_pred - ifft_truth)

--- a/radionets/evaluation/plotting.py
+++ b/radionets/evaluation/plotting.py
@@ -18,7 +18,7 @@ from radionets.evaluation.dynamic_range import calc_dr, get_boxsize
 from radionets.evaluation.blob_detection import calc_blobs
 from radionets.evaluation.contour import compute_area_ratio
 from pytorch_msssim import ms_ssim
-from matplotlib.patches import Rectangle
+from matplotlib.patches import Rectangle, Arc
 from matplotlib import cm
 from matplotlib.colors import ListedColormap
 
@@ -350,11 +350,9 @@ def visualize_source_reconstruction(
     msssim=False,
     plot_format="png",
 ):
-    from matplotlib.patches import Arc
     m_truth, n_truth, alpha_truth = calc_jet_angle(ifft_truth)
     m_pred, n_pred, alpha_pred = calc_jet_angle(ifft_pred)
     x_space = torch.arange(0, 511, 1)
-    # print(m_truth, n_truth, alpha_truth.numpy())
 
     # plt.style.use("./paper_large_3.rc")
     fig, (ax1, ax2, ax3) = plt.subplots(1, 3, figsize=(16, 10), sharey=True)


### PR DESCRIPTION
I added a visualization of the jet angles in our source plots. This refers to the referee's note:

> Figures 10, 12-14: Indicate the origin of the jet angle.

Color and other things are discussable, this is just a working version. An example can be found here: ![here](https://user-images.githubusercontent.com/23259659/151371899-6dc01e31-5506-471b-9d98-23d5eb5c630d.png)