### PR TITLE
Faster trunc norm

### DIFF
--- a/docs/changes/143.optimization.rst
+++ b/docs/changes/143.optimization.rst
@@ -1,1 +1,1 @@
-Optimize ``evaluation.utils.trunc_rvs`` with numba, providing functions compiled for cpu, parallel cpu and cuda computation.
+Optimize ``evaluation.utils.trunc_rvs`` with numba, providing functions compiled for cpu and parallel cpu computation.

--- a/docs/changes/143.optimization.rst
+++ b/docs/changes/143.optimization.rst
@@ -1,0 +1,1 @@
+Optimize ``evaluation.utils.trunc_rvs`` with numba, providing functions compiled for cpu, parallel cpu and cuda computation.

--- a/environment.yml
+++ b/environment.yml
@@ -4,11 +4,14 @@ channels:
     - fastai
     - pytorch
     - defaults
+    - conda-forge
 dependencies:
   - python>=3.6
   - pytorch>=1.6
   - cudatoolkit
   - cartopy
+  - numpy
+  - numba
   - pip
   - pip:
     - towncrier

--- a/radionets/evaluation/utils.py
+++ b/radionets/evaluation/utils.py
@@ -594,7 +594,7 @@ def trunc_rvs(mu, sig, num_samples, mode, target="cpu", nthreads=1):
         set_num_threads(int(nthreads))
         res = tn_numba_vec_parallel(mu, sig, a, b)
     else:
-        raise ValueError("Unsupported target, use cpu, parallel or cuda.")
+        raise ValueError("Unsupported target, use cpu or parallel.")
 
     return res.swapaxes(0, 1)
 

--- a/radionets/evaluation/utils.py
+++ b/radionets/evaluation/utils.py
@@ -6,7 +6,7 @@ import torch
 import torch.nn.functional as F
 from torch.utils.data import DataLoader
 import h5py
-from numba import float64, vectorize, set_num_threads
+from numba import vectorize, set_num_threads
 from pathlib import Path
 
 

--- a/radionets/evaluation/utils.py
+++ b/radionets/evaluation/utils.py
@@ -582,7 +582,8 @@ def trunc_rvs(mu, sig, num_samples, mode, target="cpu", nthreads=1):
     if target == "cpu":
         if nthreads > 1:
             raise ValueError(
-                f"Target is ``cpu`` but nthreads is {nthreads}, use target=``parallel`` instead."
+                f"Target is ``cpu`` but nthreads is {nthreads}, " 
+                "use target=``parallel`` instead."
             )
         res = tn_numba_vec_cpu(mu, sig, a, b)
     elif target == "parallel":

--- a/radionets/evaluation/utils.py
+++ b/radionets/evaluation/utils.py
@@ -567,17 +567,6 @@ def tn_numba_vec_parallel(mu, sig, a, b):
     return rv
 
 
-@vectorize(["float64(float64, float64, float64, float64)"], target="cuda")
-def tn_numba_vec_cuda(mu, sig, a, b):
-    rv = np.random.normal(loc=mu, scale=sig)
-    cond = rv > a and rv < b
-    while not cond:
-        rv = np.random.normal(loc=mu, scale=sig)
-        cond = rv > a and rv < b
-
-    return rv
-
-
 def trunc_rvs(mu, sig, num_samples, mode, target="cpu", nthreads=1):
     if mode == "amp":
         a = 0
@@ -603,8 +592,6 @@ def trunc_rvs(mu, sig, num_samples, mode, target="cpu", nthreads=1):
             )
         set_num_threads(int(nthreads))
         res = tn_numba_vec_parallel(mu, sig, a, b)
-    elif target == "cuda":
-        res = tn_numba_vec_cuda(mu, sig, a, b)
     else:
         raise ValueError("Unsupported target, use cpu, parallel or cuda.")
 

--- a/radionets/evaluation/utils.py
+++ b/radionets/evaluation/utils.py
@@ -6,6 +6,7 @@ import torch
 import torch.nn.functional as F
 from torch.utils.data import DataLoader
 import h5py
+from numba import float64, vectorize, set_num_threads
 from pathlib import Path
 
 
@@ -544,23 +545,70 @@ def even_better_symmetry(x):
     return x
 
 
-def trunc_rvs(loc, scale, mode, num_samples, num_img):
-    from scipy.stats import truncnorm
+@vectorize(["float64(float64, float64, float64, float64)"], target="cpu")
+def tn_numba_vec_cpu(mu, sig, a, b):
+    rv = np.random.normal(loc=mu, scale=sig)
+    cond = rv > a and rv < b
+    while not cond:
+        rv = np.random.normal(loc=mu, scale=sig)
+        cond = rv > a and rv < b
 
+    return rv
+
+
+@vectorize(["float64(float64, float64, float64, float64)"], target="parallel")
+def tn_numba_vec_parallel(mu, sig, a, b):
+    rv = np.random.normal(loc=mu, scale=sig)
+    cond = rv > a and rv < b
+    while not cond:
+        rv = np.random.normal(loc=mu, scale=sig)
+        cond = rv > a and rv < b
+
+    return rv
+
+
+@vectorize(["float64(float64, float64, float64, float64)"], target="cuda")
+def tn_numba_vec_cuda(mu, sig, a, b):
+    rv = np.random.normal(loc=mu, scale=sig)
+    cond = rv > a and rv < b
+    while not cond:
+        rv = np.random.normal(loc=mu, scale=sig)
+        cond = rv > a and rv < b
+
+    return rv
+
+
+def trunc_rvs(mu, sig, num_samples, mode, target="cpu", nthreads=1):
     if mode == "amp":
-        myclip_a = 0
-        myclip_b = np.inf
+        a = 0
+        b = np.inf
     elif mode == "phase":
-        myclip_a = -np.pi
-        myclip_b = np.pi
+        a = -np.pi
+        b = np.pi
     else:
-        raise ValueError("Wrong mode!")
-    a, b = (myclip_a - loc) / scale, (myclip_b - loc) / scale
-    sampled_gauss = truncnorm.rvs(
-        a, b, loc=loc, scale=scale, size=(num_samples, num_img, 65, 128)
-    )
+        raise ValueError("Unsupported mode, use either ``phase`` or ``amp``.")
+    mu = np.tile(mu, (num_samples, 1, 1, 1))
+    sig = np.tile(sig, (num_samples, 1, 1, 1))
 
-    return sampled_gauss.swapaxes(0, 1)
+    if target == "cpu":
+        if nthreads > 1:
+            raise ValueError(
+                f"Target is ``cpu`` but nthreads is {nthreads}, use target=``parallel`` instead."
+            )
+        res = tn_numba_vec_cpu(mu, sig, a, b)
+    elif target == "parallel":
+        if nthreads == 1:
+            raise ValueError(
+                "Target is ``parallel`` but nthreaads is 1, use target=``cpu`` instead."
+            )
+        set_num_threads(int(nthreads))
+        res = tn_numba_vec_parallel(mu, sig, a, b)
+    elif target == "cuda":
+        res = tn_numba_vec_cuda(mu, sig, a, b)
+    else:
+        raise ValueError("Unsupported target, use cpu, parallel or cuda.")
+
+    return res.swapaxes(0, 1)
 
 
 def sample_images(mean, std, num_samples):
@@ -589,12 +637,18 @@ def sample_images(mean, std, num_samples):
 
     # amplitude
     sampled_gauss_amp = trunc_rvs(
-        mean_amp, std_amp, "amp", num_samples, num_img
+        mu=mean_amp,
+        sig=std_amp,
+        mode="amp",
+        num_samples=num_samples,
     ).reshape(num_img * num_samples, 65, 128)
 
     # phase
     sampled_gauss_phase = trunc_rvs(
-        mean_phase, std_phase, "phase", num_samples, num_img
+        mu=mean_phase,
+        sig=std_phase,
+        mode="phase",
+        num_samples=num_samples,
     ).reshape(num_img * num_samples, 65, 128)
 
     # masks

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ setup(
         "astropy",
         "tqdm",
         "click",
+        "numba",
         "jupyter",
         "h5py",
         "scikit-image",

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -359,12 +359,22 @@ class TestEvaluation:
 
         # amplitude
         sampled_gauss_amp = trunc_rvs(
-            mean_amp, std_amp, "amp", num_samples, num_img=num_img
+            mean_amp,
+            std_amp,
+            mode="amp",
+            num_samples=num_samples,
+            target="cpu",
+            nthreads=1,
         )
 
         # phase
         sampled_gauss_phase = trunc_rvs(
-            mean_phase, std_phase, "phase", num_samples, num_img=num_img
+            mean_phase,
+            std_phase,
+            mode="phase",
+            num_sampels=num_samples,
+            target="cpu",
+            nthreads=1,
         )
 
         assert sampled_gauss_amp.shape == (

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -395,9 +395,46 @@ class TestEvaluation:
             num_img * num_samples, 65, 128
         )
 
+        # Unknown mode
         with pytest.raises(ValueError):
-            trunc_rvs(mean_phase, std_phase, "pase", num_samples, num_img=num_img)
-
+            trunc_rvs(mean_phase, 
+                      std_phase, 
+                      mode="pase", 
+                      num_samples=num_samples,
+                      target="cpu",
+                      nthreads=1,
+            )
+            
+        # Unknown target
+        with pytest.raises(ValueError):
+            trunc_rvs(mean_phase, 
+                      std_phase, 
+                      mode="phase", 
+                      num_samples=num_samples,
+                      target="cp",
+                      nthreads=1,
+            )
+            
+        # cpu but 2 threads
+        with pytest.raises(ValueError):
+            trunc_rvs(mean_phase, 
+                      std_phase, 
+                      mode="phase", 
+                      num_samples=num_samples,
+                      target="cpu",
+                      nthreads=2,
+            )
+            
+        # parallel but only one thread    
+        with pytest.raises(ValueError):
+            trunc_rvs(mean_phase, 
+                      std_phase, 
+                      mode="phase", 
+                      num_samples=num_samples,
+                      target="parallel",
+                      nthreads=1,
+            )
+       
         # masks
         mask_invalid_amp = sampled_gauss_amp < 0
         mask_invalid_phase = (sampled_gauss_phase <= (-np.pi - 1e-4)) | (

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -372,7 +372,7 @@ class TestEvaluation:
             mean_phase,
             std_phase,
             mode="phase",
-            num_sampels=num_samples,
+            num_samples=num_samples,
             target="cpu",
             nthreads=1,
         )


### PR DESCRIPTION
Utilizing numba for faster truncnorm computation. You can use this notebook to test the functions a bit (.zip, as github does not support .ipynb in PR comments):

[Truncnorm.zip](https://github.com/radionets-project/radionets/files/10558974/Truncnorm.zip)
