### PR TITLE
Update framework for the use of real/imag

### DIFF
--- a/docs/changes/146.feature.rst
+++ b/docs/changes/146.feature.rst
@@ -1,0 +1,4 @@
+- Add normalization callback with two different techniques
+- Update plotting routines for real/imag images
+- Update evaluate_area and evaluate_ms_ssim for half images
+- Add evaluate_ms_ssim for sampled images

--- a/docs/changes/146.maintenance.rst
+++ b/docs/changes/146.maintenance.rst
@@ -1,0 +1,5 @@
+- Add the model name to predictions and sampling file
+- Delete unnecessary pad_unsqueeze function
+- Add amp_phase keyword to sample_images
+- Fix deprecation warning in sampling.py
+- Add image size to test_evaluation.py routines

--- a/examples/default_train_config.toml
+++ b/examples/default_train_config.toml
@@ -21,6 +21,7 @@ norm_path = "none"
 [general]
 fourier = true
 amp_phase = true
+normalize = false
 source_list = false
 arch_name = "filter_deep"
 loss_func = "splitted_L1"

--- a/radionets/dl_framework/architectures/res_exp.py
+++ b/radionets/dl_framework/architectures/res_exp.py
@@ -166,8 +166,8 @@ class SRResNet_16(nn.Module):
         x = self.final(x)
 
         x0 = x[:, 0].reshape(-1, 1, s // 2 + 1, s)
-        x0 = self.relu(x0)
-        x1 = self.hardtanh(x[:, 1]).reshape(-1, 1, s // 2 + 1, s)
+        # x0 = self.relu(x0)
+        x1 = x[:, 1].reshape(-1, 1, s // 2 + 1, s)
 
         return torch.cat([x0, x1], dim=1)
 

--- a/radionets/dl_framework/callbacks.py
+++ b/radionets/dl_framework/callbacks.py
@@ -194,6 +194,31 @@ class DataAug(Callback):
         self.learn.yb = [y]
 
 
+class Normalize(Callback):
+    _order = 4
+
+    def __init__(self, train_conf):
+        self.mean_real = train_conf["norm_factors"]["mean_real"]
+        self.mean_imag = train_conf["norm_factors"]["mean_imag"]
+        self.std_real = train_conf["norm_factors"]["std_real"]
+        self.std_imag = train_conf["norm_factors"]["std_imag"]
+
+    def normalize(self, x, m, s):
+        return (x - m) / s
+
+    def before_batch(self):
+        x = self.xb[0].clone()
+        y = self.yb[0].clone()
+
+        x[:, 0] = self.normalize(x[:, 0], self.mean_real, self.std_real)
+        x[:, 1] = self.normalize(x[:, 1], self.mean_imag, self.std_imag)
+        y[:, 0] = self.normalize(y[:, 0], self.mean_real, self.std_real)
+        y[:, 1] = self.normalize(y[:, 1], self.mean_imag, self.std_imag)
+
+        self.learn.xb = [x]
+        self.learn.yb = [y]
+
+
 class SaveTempCallback(Callback):
     _order = 95
 

--- a/radionets/dl_framework/learner.py
+++ b/radionets/dl_framework/learner.py
@@ -51,7 +51,6 @@ def define_learner(data, arch, train_conf, lr_find=False, plot_loss=False):
             SaveTempCallback(model_path=model_path),
             AvgLossCallback,
             DataAug,
-            Normalize(train_conf=train_conf),
         ]
     )
 
@@ -79,6 +78,8 @@ def define_learner(data, arch, train_conf, lr_find=False, plot_loss=False):
             ]
         )
 
+    if not lr_find and not plot_loss:
+        cbfs.extend([Normalize(train_conf=train_conf)])
     # get loss func
     if train_conf["loss_func"] == "feature_loss":
         loss_func = loss_functions.init_feature_loss()

--- a/radionets/dl_framework/learner.py
+++ b/radionets/dl_framework/learner.py
@@ -78,8 +78,8 @@ def define_learner(data, arch, train_conf, lr_find=False, plot_loss=False):
             ]
         )
 
-    if not lr_find and not plot_loss:
-        cbfs.extend([Normalize(train_conf=train_conf)])
+    if not lr_find and not plot_loss and train_conf["normalize"] != "none":
+        cbfs.extend([Normalize(train_conf)])
     # get loss func
     if train_conf["loss_func"] == "feature_loss":
         loss_func = loss_functions.init_feature_loss()

--- a/radionets/dl_framework/learner.py
+++ b/radionets/dl_framework/learner.py
@@ -7,6 +7,7 @@ from radionets.dl_framework.callbacks import (
     SwitchLoss,
     CudaCallback,
     CometCallback,
+    Normalize,
 )
 from fastai.optimizer import Adam
 from fastai.learner import Learner
@@ -50,6 +51,7 @@ def define_learner(data, arch, train_conf, lr_find=False, plot_loss=False):
             SaveTempCallback(model_path=model_path),
             AvgLossCallback,
             DataAug,
+            Normalize(train_conf=train_conf),
         ]
     )
 

--- a/radionets/dl_framework/model.py
+++ b/radionets/dl_framework/model.py
@@ -171,7 +171,7 @@ def load_pre_model(learn, pre_path, visualize=False, plot_loss=False):
 
 
 def save_model(learn, model_path):
-    if hasattr(learn, "normalize"):
+    if hasattr(learn, "mean_real"):
         norm_dict = {
             "mean_real": learn.normalize.mean_real,
             "mean_imag": learn.normalize.mean_imag,

--- a/radionets/dl_framework/model.py
+++ b/radionets/dl_framework/model.py
@@ -155,6 +155,8 @@ def load_pre_model(learn, pre_path, visualize=False, plot_loss=False):
 
     if visualize:
         learn.load_state_dict(checkpoint["model"])
+        if "norm_dict" in checkpoint:
+            return checkpoint["norm_dict"]
     elif plot_loss:
         learn.avg_loss.loss_train = checkpoint["train_loss"]
         learn.avg_loss.loss_valid = checkpoint["valid_loss"]
@@ -171,13 +173,16 @@ def load_pre_model(learn, pre_path, visualize=False, plot_loss=False):
 
 
 def save_model(learn, model_path):
-    if hasattr(learn, "mean_real"):
-        norm_dict = {
-            "mean_real": learn.normalize.mean_real,
-            "mean_imag": learn.normalize.mean_imag,
-            "std_real": learn.normalize.std_real,
-            "std_imag": learn.normalize.std_imag,
-        }
+    if hasattr(learn, "normalize"):
+        if hasattr(learn.normalize, "mean_real"):
+            norm_dict = {
+                "mean_real": learn.normalize.mean_real,
+                "mean_imag": learn.normalize.mean_imag,
+                "std_real": learn.normalize.std_real,
+                "std_imag": learn.normalize.std_imag,
+            }
+        else:
+            norm_dict = {"max_scaling": 0}
     else:
         norm_dict = {}
 

--- a/radionets/dl_framework/model.py
+++ b/radionets/dl_framework/model.py
@@ -171,12 +171,15 @@ def load_pre_model(learn, pre_path, visualize=False, plot_loss=False):
 
 
 def save_model(learn, model_path):
-    norm_dict = {
-        "mean_real": learn.normalize.mean_real,
-        "mean_imag": learn.normalize.mean_imag,
-        "std_real": learn.normalize.std_real,
-        "std_imag": learn.normalize.std_imag,
-    }
+    if hasattr(learn, "normalize"):
+        norm_dict = {
+            "mean_real": learn.normalize.mean_real,
+            "mean_imag": learn.normalize.mean_imag,
+            "std_real": learn.normalize.std_real,
+            "std_imag": learn.normalize.std_imag,
+        }
+    else:
+        norm_dict = {}
 
     torch.save(
         {

--- a/radionets/dl_framework/model.py
+++ b/radionets/dl_framework/model.py
@@ -171,6 +171,13 @@ def load_pre_model(learn, pre_path, visualize=False, plot_loss=False):
 
 
 def save_model(learn, model_path):
+    norm_dict = {
+        "mean_real": learn.normalize.mean_real,
+        "mean_imag": learn.normalize.mean_imag,
+        "std_real": learn.normalize.std_real,
+        "std_imag": learn.normalize.std_imag,
+    }
+
     torch.save(
         {
             "model": learn.model.state_dict(),
@@ -181,6 +188,7 @@ def save_model(learn, model_path):
             "train_loss": learn.avg_loss.loss_train,
             "valid_loss": learn.avg_loss.loss_valid,
             "lrs": learn.avg_loss.lrs,
+            "norm_dict": norm_dict,
         },
         model_path,
     )

--- a/radionets/dl_training/scripts/start_training.py
+++ b/radionets/dl_training/scripts/start_training.py
@@ -8,6 +8,7 @@ from radionets.dl_training.utils import (
     define_arch,
     pop_interrupt,
     end_training,
+    get_normalisation_factors,
 )
 from radionets.dl_framework.learner import define_learner
 from radionets.dl_framework.model import load_pre_model
@@ -65,6 +66,8 @@ def main(configuration_path, mode):
     arch = define_arch(
         arch_name=train_conf["arch_name"], img_size=train_conf["image_size"]
     )
+
+    train_conf["norm_factors"] = get_normalisation_factors(data)
 
     if mode == "train":
         # check out path and look for existing model files

--- a/radionets/dl_training/scripts/start_training.py
+++ b/radionets/dl_training/scripts/start_training.py
@@ -68,7 +68,8 @@ def main(configuration_path, mode):
     )
 
     if mode == "train":
-        train_conf["norm_factors"] = get_normalisation_factors(data)
+        if train_conf["normalize"] == "mean":
+            train_conf["norm_factors"] = get_normalisation_factors(data)
         # check out path and look for existing model files
         check_outpath(train_conf["model_path"], train_conf)
 

--- a/radionets/dl_training/scripts/start_training.py
+++ b/radionets/dl_training/scripts/start_training.py
@@ -67,9 +67,8 @@ def main(configuration_path, mode):
         arch_name=train_conf["arch_name"], img_size=train_conf["image_size"]
     )
 
-    train_conf["norm_factors"] = get_normalisation_factors(data)
-
     if mode == "train":
+        train_conf["norm_factors"] = get_normalisation_factors(data)
         # check out path and look for existing model files
         check_outpath(train_conf["model_path"], train_conf)
 

--- a/radionets/dl_training/utils.py
+++ b/radionets/dl_training/utils.py
@@ -40,6 +40,7 @@ def read_config(config):
 
     train_conf["fourier"] = config["general"]["fourier"]
     train_conf["amp_phase"] = config["general"]["amp_phase"]
+    train_conf["normalize"] = config["general"]["normalize"]
     train_conf["arch_name"] = config["general"]["arch_name"]
     train_conf["loss_func"] = config["general"]["loss_func"]
     train_conf["num_epochs"] = config["general"]["num_epochs"]

--- a/radionets/dl_training/utils.py
+++ b/radionets/dl_training/utils.py
@@ -1,4 +1,6 @@
 import sys
+import torch
+from tqdm import tqdm
 import click
 from pathlib import Path
 from radionets.dl_framework.data import load_data, DataBunch, get_dls
@@ -108,3 +110,34 @@ def end_training(learn, train_conf):
 
     # Plot loss
     plot_loss(learn, Path(train_conf["model_path"]))
+
+
+def get_normalisation_factors(data):
+    mean_real = []
+    mean_imag = []
+    std_real = []
+    std_imag = []
+
+    for inp, true in tqdm(data.train_ds):
+        mean_batch_imag = inp[1].mean()
+        mean_batch_real = inp[0].mean()
+        std_batch_imag = inp[1].std()
+        std_batch_real = inp[0].std()
+        mean_real.append(mean_batch_real)
+        mean_imag.append(mean_batch_imag)
+        std_real.append(std_batch_real)
+        std_imag.append(std_batch_imag)
+
+    mean_real = torch.tensor(mean_real).mean()
+    mean_imag = torch.tensor(mean_imag).mean()
+    std_real = torch.tensor(std_real).std()
+    std_imag = torch.tensor(std_imag).std()
+
+    norm_factors = {
+        "mean_real": mean_real,
+        "mean_imag": mean_imag,
+        "std_real": std_real,
+        "std_imag": std_imag,
+    }
+
+    return norm_factors

--- a/radionets/evaluation/plotting.py
+++ b/radionets/evaluation/plotting.py
@@ -235,15 +235,12 @@ def visualize_with_fourier(
         im6 = ax6.imshow(imag_truth, cmap="RdBu", vmin=-np.pi, vmax=np.pi)
         make_axes_nice(fig, ax6, im6, r"Phase Truth", phase=True)
     else:
-        # a = check_vmin_vmax(inp_real)
         im1 = ax1.imshow(inp_real, cmap="RdBu")
         make_axes_nice(fig, ax1, im1, r"Real Input")
 
-        # a = check_vmin_vmax(real_truth)
         im2 = ax2.imshow(real_pred, cmap="RdBu")
         make_axes_nice(fig, ax2, im2, r"Real Prediction")
 
-        # a = check_vmin_vmax(real_truth)
         im3 = ax3.imshow(real_truth, cmap="RdBu")
         make_axes_nice(fig, ax3, im3, r"Real Truth")
 
@@ -318,26 +315,26 @@ def visualize_with_fourier_diff(
 
     else:
         im1 = ax1.imshow(real_pred, cmap="inferno")
-        make_axes_nice(fig, ax1, im1, r"Amplitude Prediction")
+        make_axes_nice(fig, ax1, im1, r"Real Prediction")
 
         im2 = ax2.imshow(real_truth, cmap="inferno")
-        make_axes_nice(fig, ax2, im2, r"Amplitude Truth")
+        make_axes_nice(fig, ax2, im2, "Real Truth")
 
         a = check_vmin_vmax(real_pred - real_truth)
         im3 = ax3.imshow(real_pred - real_truth, cmap=OrBu, vmin=-a, vmax=a)
-        make_axes_nice(fig, ax3, im3, r"Amplitude Difference")
+        make_axes_nice(fig, ax3, im3, r"Real Difference")
 
         a = check_vmin_vmax(imag_truth)
         im4 = ax4.imshow(imag_pred, cmap=OrBu)
-        make_axes_nice(fig, ax4, im4, r"Phase Prediction")
+        make_axes_nice(fig, ax4, im4, r"Imaginary Prediction")
 
         a = check_vmin_vmax(imag_truth)
         im5 = ax5.imshow(imag_truth, cmap=OrBu)
-        make_axes_nice(fig, ax5, im5, r"Phase Truth")
+        make_axes_nice(fig, ax5, im5, r"Imaginary Truth")
 
         a = check_vmin_vmax(imag_pred - imag_truth)
         im6 = ax6.imshow(imag_pred - imag_truth, cmap=OrBu)
-        make_axes_nice(fig, ax6, im6, r"Phase Difference")
+        make_axes_nice(fig, ax6, im6, r"Imaginary Difference")
 
     ax1.set_ylabel(r"Pixels")
     ax4.set_ylabel(r"Pixels")

--- a/radionets/evaluation/plotting.py
+++ b/radionets/evaluation/plotting.py
@@ -235,28 +235,28 @@ def visualize_with_fourier(
         im6 = ax6.imshow(imag_truth, cmap="RdBu", vmin=-np.pi, vmax=np.pi)
         make_axes_nice(fig, ax6, im6, r"Phase Truth", phase=True)
     else:
-        a = check_vmin_vmax(inp_real)
-        im1 = ax1.imshow(inp_real, cmap="RdBu", vmin=-a, vmax=a)
+        # a = check_vmin_vmax(inp_real)
+        im1 = ax1.imshow(inp_real, cmap="RdBu")
         make_axes_nice(fig, ax1, im1, r"Real Input")
 
-        a = check_vmin_vmax(real_truth)
-        im2 = ax2.imshow(real_pred, cmap="RdBu", vmin=-a, vmax=a)
+        # a = check_vmin_vmax(real_truth)
+        im2 = ax2.imshow(real_pred, cmap="RdBu")
         make_axes_nice(fig, ax2, im2, r"Real Prediction")
 
-        a = check_vmin_vmax(real_truth)
-        im3 = ax3.imshow(real_truth, cmap="RdBu", vmin=-a, vmax=a)
+        # a = check_vmin_vmax(real_truth)
+        im3 = ax3.imshow(real_truth, cmap="RdBu")
         make_axes_nice(fig, ax3, im3, r"Real Truth")
 
         a = check_vmin_vmax(inp_imag)
-        im4 = ax4.imshow(inp_imag, cmap="RdBu", vmin=-a, vmax=a)
+        im4 = ax4.imshow(inp_imag, cmap="RdBu")
         make_axes_nice(fig, ax4, im4, r"Imaginary Input")
 
         a = check_vmin_vmax(imag_truth)
-        im5 = ax5.imshow(imag_pred, cmap="RdBu", vmin=-np.pi, vmax=np.pi)
+        im5 = ax5.imshow(imag_pred, cmap="RdBu")
         make_axes_nice(fig, ax5, im5, r"Imaginary Prediction")
 
         a = check_vmin_vmax(imag_truth)
-        im6 = ax6.imshow(imag_truth, cmap="RdBu", vmin=-np.pi, vmax=np.pi)
+        im6 = ax6.imshow(imag_truth, cmap="RdBu")
         make_axes_nice(fig, ax6, im6, r"Imaginary Truth")
 
     ax1.set_ylabel(r"Pixels")
@@ -315,6 +315,29 @@ def visualize_with_fourier_diff(
             imag_pred - imag_truth, cmap=OrBu, vmin=-2 * np.pi, vmax=2 * np.pi
         )
         make_axes_nice(fig, ax6, im6, r"Phase Difference", phase_diff=True)
+
+    else:
+        im1 = ax1.imshow(real_pred, cmap="inferno")
+        make_axes_nice(fig, ax1, im1, r"Amplitude Prediction")
+
+        im2 = ax2.imshow(real_truth, cmap="inferno")
+        make_axes_nice(fig, ax2, im2, r"Amplitude Truth")
+
+        a = check_vmin_vmax(real_pred - real_truth)
+        im3 = ax3.imshow(real_pred - real_truth, cmap=OrBu, vmin=-a, vmax=a)
+        make_axes_nice(fig, ax3, im3, r"Amplitude Difference")
+
+        a = check_vmin_vmax(imag_truth)
+        im4 = ax4.imshow(imag_pred, cmap=OrBu)
+        make_axes_nice(fig, ax4, im4, r"Phase Prediction")
+
+        a = check_vmin_vmax(imag_truth)
+        im5 = ax5.imshow(imag_truth, cmap=OrBu)
+        make_axes_nice(fig, ax5, im5, r"Phase Truth")
+
+        a = check_vmin_vmax(imag_pred - imag_truth)
+        im6 = ax6.imshow(imag_pred - imag_truth, cmap=OrBu)
+        make_axes_nice(fig, ax6, im6, r"Phase Difference")
 
     ax1.set_ylabel(r"Pixels")
     ax4.set_ylabel(r"Pixels")

--- a/radionets/evaluation/plotting.py
+++ b/radionets/evaluation/plotting.py
@@ -323,15 +323,12 @@ def visualize_with_fourier_diff(
         im3 = ax3.imshow(real_pred - real_truth, cmap=OrBu, vmin=-a, vmax=a)
         make_axes_nice(fig, ax3, im3, r"Real Difference")
 
-        a = check_vmin_vmax(imag_truth)
         im4 = ax4.imshow(imag_pred, cmap=OrBu)
         make_axes_nice(fig, ax4, im4, r"Imaginary Prediction")
 
-        a = check_vmin_vmax(imag_truth)
         im5 = ax5.imshow(imag_truth, cmap=OrBu)
         make_axes_nice(fig, ax5, im5, r"Imaginary Truth")
 
-        a = check_vmin_vmax(imag_pred - imag_truth)
         im6 = ax6.imshow(imag_pred - imag_truth, cmap=OrBu)
         make_axes_nice(fig, ax6, im6, r"Imaginary Difference")
 

--- a/radionets/evaluation/plotting.py
+++ b/radionets/evaluation/plotting.py
@@ -423,19 +423,19 @@ def visualize_uncertainty(
         2, 2, sharey=True, sharex=True, figsize=(12, 10)
     )
 
-    im1 = ax1.imshow(true_phase, cmap=OrBu, vmin=-np.pi, vmax=np.pi)
+    im1 = ax1.imshow(true_phase, cmap=OrBu)
 
-    im2 = ax2.imshow(pred_phase, cmap=OrBu, vmin=-np.pi, vmax=np.pi)
+    im2 = ax2.imshow(pred_phase, cmap=OrBu)
 
     im3 = ax3.imshow(unc_phase)
 
     a = check_vmin_vmax(true_phase - pred_phase)
     im4 = ax4.imshow(true_phase - pred_phase, cmap=OrBu, vmin=-a, vmax=a)
 
-    make_axes_nice(fig, ax1, im1, r"Simulation", phase=True)
-    make_axes_nice(fig, ax2, im2, r"Predicted $\mu$", phase=True)
+    make_axes_nice(fig, ax1, im1, r"Simulation")
+    make_axes_nice(fig, ax2, im2, r"Predicted $\mu$")
     make_axes_nice(fig, ax3, im3, r"Predicted $\sigma^2$", unc=True)
-    make_axes_nice(fig, ax4, im4, r"Difference", phase_diff=True)
+    make_axes_nice(fig, ax4, im4, r"Difference")
 
     ax1.set_ylabel(r"pixels")
     ax3.set_ylabel(r"pixels")
@@ -640,7 +640,7 @@ def histogram_ms_ssim(msssim, out_path, plot_format="png"):
     fig, (ax1) = plt.subplots(1, figsize=(6, 4))
     ax1.hist(
         msssim.numpy(),
-        51,
+        80,
         color="darkorange",
         linewidth=3,
         histtype="step",

--- a/radionets/evaluation/plotting.py
+++ b/radionets/evaluation/plotting.py
@@ -16,7 +16,6 @@ from radionets.evaluation.dynamic_range import calc_dr, get_boxsize
 from radionets.evaluation.utils import (
     check_vmin_vmax,
     make_axes_nice,
-    pad_unsqueeze,
     reshape_2d,
 )
 from radionets.simulations.utils import adjust_outpath
@@ -389,11 +388,16 @@ def visualize_source_reconstruction(
         plot_box(ax2, num_boxes, corners[0])
 
     if msssim:
-        ifft_truth = pad_unsqueeze(torch.tensor(ifft_truth).unsqueeze(0))
-        ifft_pred = pad_unsqueeze(torch.tensor(ifft_pred).unsqueeze(0))
-        val = ms_ssim(ifft_pred, ifft_truth, data_range=ifft_truth.max())
-
-        ax1.plot([], [], " ", label=f"ms ssim: {val:.2f}")
+        val = ms_ssim(
+            torch.tensor(ifft_pred).unsqueeze(0).unsqueeze(0),
+            torch.tensor(ifft_truth).unsqueeze(0).unsqueeze(0),
+            data_range=1,
+            win_size=7,
+            size_average=False,
+        )
+        val = val.numpy()[0]
+        ax1.plot([], [], " ", label=f"MS-SSIM: {val:.2f}")
+        ax1.legend(loc="best")
 
     outpath = str(out_path) + f"/fft_pred_{i}.{plot_format}"
 

--- a/radionets/evaluation/scripts/start_evaluation.py
+++ b/radionets/evaluation/scripts/start_evaluation.py
@@ -11,7 +11,7 @@ from radionets.evaluation.train_inspection import (
     evaluate_dynamic_range,
     evaluate_ms_ssim_sampled,
     evaluate_mean_diff,
-    evaluate_area,
+    evaluate_area_sampled,
     evaluate_point,
     create_predictions,
     evaluate_gan_sources,
@@ -105,7 +105,7 @@ def main(configuration_path):
 
     if eval_conf["area"]:
         click.echo("\nStart evaluation of the area.\n")
-        evaluate_area(eval_conf)
+        evaluate_area_sampled(eval_conf)
 
     if eval_conf["point"]:
         click.echo("\nStart evaluation of point sources.\n")

--- a/radionets/evaluation/scripts/start_evaluation.py
+++ b/radionets/evaluation/scripts/start_evaluation.py
@@ -9,7 +9,7 @@ from radionets.evaluation.train_inspection import (
     create_contour_plots,
     evaluate_viewing_angle,
     evaluate_dynamic_range,
-    evaluate_ms_ssim,
+    evaluate_ms_ssim_sampled,
     evaluate_mean_diff,
     evaluate_area,
     evaluate_point,
@@ -97,7 +97,7 @@ def main(configuration_path):
 
     if eval_conf["ms_ssim"]:
         click.echo("\nStart evaluation of ms ssim.\n")
-        evaluate_ms_ssim(eval_conf)
+        evaluate_ms_ssim_sampled(eval_conf)
 
     if eval_conf["mean_diff"]:
         click.echo("\nStart evaluation of mean difference.\n")

--- a/radionets/evaluation/scripts/start_evaluation.py
+++ b/radionets/evaluation/scripts/start_evaluation.py
@@ -9,9 +9,9 @@ from radionets.evaluation.train_inspection import (
     create_contour_plots,
     evaluate_viewing_angle,
     evaluate_dynamic_range,
-    evaluate_ms_ssim_sampled,
+    evaluate_ms_ssim,
     evaluate_mean_diff,
-    evaluate_area_sampled,
+    evaluate_area,
     evaluate_point,
     create_predictions,
     evaluate_gan_sources,
@@ -97,7 +97,7 @@ def main(configuration_path):
 
     if eval_conf["ms_ssim"]:
         click.echo("\nStart evaluation of ms ssim.\n")
-        evaluate_ms_ssim_sampled(eval_conf)
+        evaluate_ms_ssim(eval_conf)
 
     if eval_conf["mean_diff"]:
         click.echo("\nStart evaluation of mean difference.\n")
@@ -105,7 +105,7 @@ def main(configuration_path):
 
     if eval_conf["area"]:
         click.echo("\nStart evaluation of the area.\n")
-        evaluate_area_sampled(eval_conf)
+        evaluate_area(eval_conf)
 
     if eval_conf["point"]:
         click.echo("\nStart evaluation of point sources.\n")

--- a/radionets/evaluation/train_inspection.py
+++ b/radionets/evaluation/train_inspection.py
@@ -84,11 +84,7 @@ def get_prediction(conf, mode="test"):
     img_size = img_test.shape[-1]
     model = load_pretrained_model(conf["arch_name"], conf["model_path"], img_size)
 
-    img_test[:, 0] = (img_test[:, 0] - 0.0931) / 1.0073
-    img_test[:, 1] = (img_test[:, 1] - -0.0093) / 0.4720
     pred = eval_model(img_test, model)
-    pred[:, 0] = pred[:, 0] * 1.0073 + 0.0931
-    pred[:, 1] = pred[:, 1] * 0.4720 - 0.0093
     images = {"pred": pred, "inp": img_test, "true": img_true}
 
     if pred.shape[1] == 4:
@@ -485,11 +481,7 @@ def evaluate_ms_ssim(conf):
     # iterate trough DataLoader
     for i, (img_test, img_true) in enumerate(tqdm(loader)):
 
-        img_test[:, 0] = (img_test[:, 0] - 0.0931) / 1.0073
-        img_test[:, 1] = (img_test[:, 1] - -0.0093) / 0.4720
         pred = eval_model(img_test, model)
-        pred[:, 0] = pred[:, 0] * 1.0073 + 0.0931
-        pred[:, 1] = pred[:, 1] * 0.4720 - 0.0093
         if conf["model_path_2"] != "none":
             pred_2 = eval_model(img_test, model_2)
             pred = torch.cat((pred, pred_2), dim=1)
@@ -706,11 +698,7 @@ def evaluate_area(conf):
     # iterate trough DataLoader
     for i, (img_test, img_true) in enumerate(tqdm(loader)):
 
-        img_test[:, 0] = (img_test[:, 0] - 0.0931) / 1.0073
-        img_test[:, 1] = (img_test[:, 1] - -0.0093) / 0.4720
         pred = eval_model(img_test, model)
-        pred[:, 0] = pred[:, 0] * 1.0073 + 0.0931
-        pred[:, 1] = pred[:, 1] * 0.4720 - 0.0093
         if conf["model_path_2"] != "none":
             pred_2 = eval_model(img_test, model_2)
             pred = torch.cat((pred, pred_2), dim=1)

--- a/radionets/evaluation/train_inspection.py
+++ b/radionets/evaluation/train_inspection.py
@@ -485,7 +485,11 @@ def evaluate_ms_ssim(conf):
     # iterate trough DataLoader
     for i, (img_test, img_true) in enumerate(tqdm(loader)):
 
+        img_test[:, 0] = (img_test[:, 0] - 0.0931) / 1.0073
+        img_test[:, 1] = (img_test[:, 1] - -0.0093) / 0.4720
         pred = eval_model(img_test, model)
+        pred[:, 0] = pred[:, 0] * 1.0073 + 0.0931
+        pred[:, 1] = pred[:, 1] * 0.4720 - 0.0093
         if conf["model_path_2"] != "none":
             pred_2 = eval_model(img_test, model_2)
             pred = torch.cat((pred, pred_2), dim=1)
@@ -701,7 +705,11 @@ def evaluate_area(conf):
     # iterate trough DataLoader
     for i, (img_test, img_true) in enumerate(tqdm(loader)):
 
+        img_test[:, 0] = (img_test[:, 0] - 0.0931) / 1.0073
+        img_test[:, 1] = (img_test[:, 1] - -0.0093) / 0.4720
         pred = eval_model(img_test, model)
+        pred[:, 0] = pred[:, 0] * 1.0073 + 0.0931
+        pred[:, 1] = pred[:, 1] * 0.4720 - 0.0093
         if conf["model_path_2"] != "none":
             pred_2 = eval_model(img_test, model_2)
             pred = torch.cat((pred, pred_2), dim=1)

--- a/radionets/evaluation/train_inspection.py
+++ b/radionets/evaluation/train_inspection.py
@@ -495,10 +495,11 @@ def evaluate_ms_ssim(conf):
             pred = torch.cat((pred, pred_2), dim=1)
 
         # apply symmetry
-        img_dict = {"truth": img_true, "pred": pred}
-        img_dict = apply_symmetry(img_dict)
-        img_true = img_dict["truth"]
-        pred = img_dict["pred"]
+        if pred.shape[-1] == 128:
+            img_dict = {"truth": img_true, "pred": pred}
+            img_dict = apply_symmetry(img_dict)
+            img_true = img_dict["truth"]
+            pred = img_dict["pred"]
 
         ifft_truth = torch.tensor(get_ifft(img_true, amp_phase=conf["amp_phase"]))
         ifft_pred = torch.tensor(get_ifft(pred, amp_phase=conf["amp_phase"]))
@@ -715,10 +716,11 @@ def evaluate_area(conf):
             pred = torch.cat((pred, pred_2), dim=1)
 
         # apply symmetry
-        img_dict = {"truth": img_true, "pred": pred}
-        img_dict = apply_symmetry(img_dict)
-        img_true = img_dict["truth"]
-        pred = img_dict["pred"]
+        if pred.shape[-1] == 128:
+            img_dict = {"truth": img_true, "pred": pred}
+            img_dict = apply_symmetry(img_dict)
+            img_true = img_dict["truth"]
+            pred = img_dict["pred"]
 
         ifft_truth = get_ifft(img_true, amp_phase=conf["amp_phase"])
         ifft_pred = get_ifft(pred, amp_phase=conf["amp_phase"])

--- a/radionets/evaluation/train_inspection.py
+++ b/radionets/evaluation/train_inspection.py
@@ -52,10 +52,13 @@ def create_predictions(conf):
         img = get_separate_prediction(conf)
     else:
         img = get_prediction(conf)
+
     model_path = conf["model_path"]
+    name_model = Path(model_path).stem
+
     out_path = Path(model_path).parent / "evaluation"
     out_path.mkdir(parents=True, exist_ok=True)
-    out_path = str(out_path) + "/predictions.h5"
+    out_path = str(out_path) + f"/predictions_{name_model}.h5"
 
     if not conf["fourier"]:
         click.echo("\n This is not a fourier dataset.\n")
@@ -151,7 +154,8 @@ def get_separate_prediction(conf):
 def create_inspection_plots(conf, num_images=3, rand=False):
     model_path = conf["model_path"]
     path = str(Path(model_path).parent / "evaluation")
-    path += "/predictions.h5"
+    name_model = Path(model_path).stem
+    path += f"/predictions_{name_model}.h5"
     out_path = Path(model_path).parent / "evaluation/"
 
     img = read_pred(path)
@@ -261,7 +265,8 @@ def create_source_plots(conf, num_images=3, rand=False):
     """
     model_path = conf["model_path"]
     path = str(Path(model_path).parent / "evaluation")
-    path += "/predictions.h5"
+    name_model = Path(model_path).stem
+    path += f"/predictions_{name_model}.h5"
     out_path = Path(model_path).parent / "evaluation"
 
     img = read_pred(path)
@@ -293,7 +298,8 @@ def create_source_plots(conf, num_images=3, rand=False):
 def create_contour_plots(conf, num_images=3, rand=False):
     model_path = conf["model_path"]
     path = str(Path(model_path).parent / "evaluation")
-    path += "/predictions.h5"
+    name_model = Path(model_path).stem
+    path += f"/predictions_{name_model}.h5"
     out_path = Path(model_path).parent / "evaluation"
 
     if not conf["fourier"]:
@@ -325,7 +331,8 @@ def create_uncertainty_plots(conf, num_images=3, rand=False):
     """
     model_path = conf["model_path"]
     path = str(Path(model_path).parent / "evaluation")
-    predictions_path = path + "/predictions.h5"
+    name_model = Path(model_path).stem
+    predictions_path = path + f"/predictions_{name_model}.h5"
     out_path = Path(model_path).parent / "evaluation/"
 
     img = read_pred(predictions_path)

--- a/radionets/evaluation/utils.py
+++ b/radionets/evaluation/utils.py
@@ -475,7 +475,6 @@ def sym_new(image, key):
     torch.Tensor
         quadratic images after utilizing symmetry
     """
-    # set channel for phase dependent of uncertainty training
     if isinstance(image, np.ndarray):
         image = torch.tensor(image)
     upper_half = image[:, :, :64, :].clone()
@@ -495,6 +494,19 @@ def sym_new(image, key):
 
 
 def apply_symmetry(img_dict):
+    """
+    Pads and applies symmetry to half images. Takes a dict as input
+
+    Parameters
+    ----------
+    img_dict : dict
+        input dict which contains the half images
+
+    Returns
+    -------
+    dict
+        input dict with quadratic images
+    """
     for key in img_dict:
         if key != "indices":
             if isinstance(img_dict[key], np.ndarray):

--- a/radionets/evaluation/utils.py
+++ b/radionets/evaluation/utils.py
@@ -256,8 +256,8 @@ def load_pretrained_model(arch_name, model_path, img_size=63):
         arch = getattr(architecture, arch_name)(img_size)
     else:
         arch = getattr(architecture, arch_name)()
-    load_pre_model(arch, model_path, visualize=True)
-    return arch
+    norm_dict = load_pre_model(arch, model_path, visualize=True)
+    return arch, norm_dict
 
 
 def get_images(test_ds, num_images, rand=False, indices=None):

--- a/radionets/evaluation/utils.py
+++ b/radionets/evaluation/utils.py
@@ -559,7 +559,7 @@ def tn_numba_vec_parallel(mu, sig, a, b):
     return rv
 
 
-def trunc_rvs(mu, sig, num_samples, mode, target="parallel", nthreads=49):
+def trunc_rvs(mu, sig, num_samples, mode, target="cpu", nthreads=1):
     if mode == "amp":
         a = 0
         b = np.inf
@@ -570,8 +570,6 @@ def trunc_rvs(mu, sig, num_samples, mode, target="parallel", nthreads=49):
         raise ValueError("Unsupported mode, use either ``phase`` or ``amp``.")
     mu = np.tile(mu, (num_samples, 1, 1, 1))
     sig = np.tile(sig, (num_samples, 1, 1, 1))
-    a = -np.inf
-    b = np.inf
 
     if target == "cpu":
         if nthreads > 1:
@@ -634,14 +632,14 @@ def sample_images(mean, std, num_samples, conf):
     ).reshape(num_img * num_samples, 65, 128)
 
     # masks
-    # mask_invalid_amp = sampled_gauss_amp <= (0 - 1e-4)
-    # mask_invalid_phase = (sampled_gauss_phase <= (-np.pi - 1e-4)) | (
-    #     sampled_gauss_phase >= (np.pi + 1e-4)
-    # )
-    # if mask_invalid_amp.sum() > 0:
-    # print(sampled_gauss_amp[mask_invalid_amp])
-    # assert mask_invalid_amp.sum() == 0
-    # assert mask_invalid_phase.sum() == 0
+    mask_invalid_amp = sampled_gauss_amp <= (0 - 1e-4)
+    mask_invalid_phase = (sampled_gauss_phase <= (-np.pi - 1e-4)) | (
+        sampled_gauss_phase >= (np.pi + 1e-4)
+    )
+    if mask_invalid_amp.sum() > 0:
+        print(sampled_gauss_amp[mask_invalid_amp])
+    assert mask_invalid_amp.sum() == 0
+    assert mask_invalid_phase.sum() == 0
 
     sampled_gauss = np.stack([sampled_gauss_amp, sampled_gauss_phase], axis=1)
 

--- a/radionets/evaluation/utils.py
+++ b/radionets/evaluation/utils.py
@@ -475,7 +475,8 @@ def check_outpath(model_path):
     bool
         true, if the file exists
     """
-    model_path = Path(model_path).parent / "evaluation" / "predictions.h5"
+    name_model = Path(model_path).stem
+    model_path = Path(model_path).parent / "evaluation" / f"predictions_{name_model}.h5"
     path = Path(model_path)
     exists = path.exists()
     return exists

--- a/radionets/evaluation/utils.py
+++ b/radionets/evaluation/utils.py
@@ -370,27 +370,6 @@ def get_ifft(array, amp_phase=False, scale=False):
     return np.abs(np.fft.ifftshift(np.fft.ifft2(np.fft.fftshift(compl))))
 
 
-def pad_unsqueeze(tensor):
-    """Unsqueeze with zeros until the image has a length of 160 pixels.
-    Needed as a helper function for the ms_ssim, as is only operates on
-    images which are at least 160x160 pixels.
-
-    Parameters
-    ----------
-    tensor : torch.tensor
-        image to pad
-
-    Returns
-    -------
-    torch.tensor
-        padded tensor
-    """
-    while tensor.shape[-1] < 160:
-        tensor = F.pad(input=tensor, pad=(1, 1, 1, 1), mode="constant", value=0)
-    tensor = tensor.unsqueeze(1)
-    return tensor
-
-
 def fft_pred(pred, truth, amp_phase=True):
     """
     Transform predicted image and true image to local domain.

--- a/radionets/simulations/sampling.py
+++ b/radionets/simulations/sampling.py
@@ -36,7 +36,7 @@ def sample_frequencies(
 
         bundle_paths = get_fft_bundle_paths(data_path, "fft", mode)
 
-        if bundle_paths == []:
+        if bundle_paths.size == 0:
             print(f"\n No {mode} data set fft images available.\n")
 
         for path in tqdm(bundle_paths):

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -405,12 +405,12 @@ class TestEvaluation:
         )
 
         # masks
-        # mask_invalid_amp = sampled_gauss_amp < 0
-        # mask_invalid_phase = (sampled_gauss_phase <= (-np.pi - 1e-4)) | (
-        #   sampled_gauss_phase >= (np.pi + 1e-4)
-        # )
-        # assert mask_invalid_amp.sum() == 0
-        # assert mask_invalid_phase.sum() == 0
+        mask_invalid_amp = sampled_gauss_amp < 0
+        mask_invalid_phase = (sampled_gauss_phase <= (-np.pi - 1e-4)) | (
+            sampled_gauss_phase >= (np.pi + 1e-4)
+        )
+        assert mask_invalid_amp.sum() == 0
+        assert mask_invalid_phase.sum() == 0
 
         sampled_gauss = np.stack([sampled_gauss_amp, sampled_gauss_phase], axis=1)
 
@@ -475,10 +475,7 @@ def test_trunc_rv(mode, target):
     if mode == "phase":
         a, b = -np.pi, np.pi
     elif mode == "amp":
-        (a, b,) = (
-            0,
-            np.inf,
-        )
+        (a, b) = (0, np.inf)
 
     if target == "cpu":
         nthreads = 1

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -26,6 +26,7 @@ class TestEvaluation:
 
         num_images = 10
         rand = True
+        img_size = test_ds[0][0][0].shape[-1]
 
         indices = torch.arange(num_images)
         assert len(indices) == 10
@@ -34,13 +35,13 @@ class TestEvaluation:
             indices = torch.randint(0, len(test_ds), size=(num_images,))
         img_test = test_ds[indices][0]
 
-        assert img_test.shape == (10, 2, 64, 64)
+        assert img_test.shape == (10, 2, img_size, img_size)
         img_true = test_ds[indices][1]
 
         img_test, img_true, indices = get_images(test_ds, num_images, rand)
 
-        assert img_true.shape == (10, 2, 64, 64)
-        assert img_test.shape == (10, 2, 64, 64)
+        assert img_true.shape == (10, 2, img_size, img_size)
+        assert img_test.shape == (10, 2, img_size, img_size)
         assert len(indices) == 10
 
     def test_get_prediction(self):
@@ -56,11 +57,12 @@ class TestEvaluation:
         conf = read_config(config)
 
         img = get_prediction(conf)
+        img_size = img["pred"].shape[-1]
         assert str(img["pred"].device) == "cpu"
 
-        assert img["pred"].shape == (10, 2, 64, 64)
-        assert img["inp"].shape == (10, 2, 64, 64)
-        assert img["true"].shape == (10, 2, 64, 64)
+        assert img["pred"].shape == (10, 2, img_size, img_size)
+        assert img["inp"].shape == (10, 2, img_size, img_size)
+        assert img["true"].shape == (10, 2, img_size, img_size)
 
         out_path = Path("./tests/build/test_training/evaluation/")
         out_path.mkdir(parents=True, exist_ok=True)
@@ -84,14 +86,15 @@ class TestEvaluation:
         img = read_pred(
             "./tests/build/test_training/evaluation/predictions_model_eval.h5"
         )
+        img_size = img["pred"].shape[-1]
 
         ifft_pred = get_ifft(img["pred"], amp_phase=conf["amp_phase"])
         ifft_truth = get_ifft(img["true"], amp_phase=conf["amp_phase"])
 
         assert ~np.isnan([ifft_pred, ifft_truth]).any()
 
-        assert ifft_pred[0].shape == (64, 64)
-        assert ifft_truth[0].shape == (64, 64)
+        assert ifft_pred[0].shape == (img_size, img_size)
+        assert ifft_truth[0].shape == (img_size, img_size)
 
         val = area_of_contour(ifft_pred[0], ifft_truth[0])
 
@@ -108,12 +111,13 @@ class TestEvaluation:
         )
 
         image = img["pred"][0]
+        img_size = image.shape[-1]
 
         x_coords, y_coords, value = im_to_array_value(image)
 
-        assert x_coords.shape == (2, 64**2)
-        assert y_coords.shape == (2, 64**2)
-        assert value.shape == (2, 64**2)
+        assert x_coords.shape == (2, img_size**2)
+        assert y_coords.shape == (2, img_size**2)
+        assert value.shape == (2, img_size**2)
 
     def test_bmul(self):
         import torch
@@ -141,9 +145,10 @@ class TestEvaluation:
         img = read_pred(
             "./tests/build/test_training/evaluation/predictions_model_eval.h5"
         )
+        img_size = img["pred"].shape[-1]
 
         ifft_pred = get_ifft(img["pred"], conf["amp_phase"])
-        assert ifft_pred.shape == (10, 64, 64)
+        assert ifft_pred.shape == (10, img_size, img_size)
 
         pix_x, pix_y, image = im_to_array_value(torch.tensor(ifft_pred))
 
@@ -191,9 +196,10 @@ class TestEvaluation:
         img = read_pred(
             "./tests/build/test_training/evaluation/predictions_model_eval.h5"
         )
+        img_size = img["pred"].shape[-1]
 
         image = get_ifft(img["pred"], conf["amp_phase"])
-        assert image.shape == (10, 64, 64)
+        assert image.shape == (10, img_size, img_size)
 
         if not isinstance(image, torch.Tensor):
             image = torch.tensor(image)
@@ -212,7 +218,7 @@ class TestEvaluation:
         max_arr = (torch.ones(img_size, img_size, bs) * max_val).permute(2, 0, 1)
         image[image < max_arr] = 0
 
-        assert image.shape == (10, 64, 64)
+        assert image.shape == (10, img_size, img_size)
 
         m, n, alpha = calc_jet_angle(image)
 
@@ -246,12 +252,13 @@ class TestEvaluation:
         img = read_pred(
             "./tests/build/test_training/evaluation/predictions_model_eval.h5"
         )
+        img_size = img["pred"].shape[-1]
 
         ifft_pred = get_ifft(torch.tensor(img["pred"][0]), conf["amp_phase"]).reshape(
-            64, 64
+            img_size, img_size
         )
         ifft_truth = get_ifft(torch.tensor(img["true"][0]), conf["amp_phase"]).reshape(
-            64, 64
+            img_size, img_size
         )
 
         blobs_pred, blobs_truth = calc_blobs(ifft_pred, ifft_truth)
@@ -293,7 +300,7 @@ class TestEvaluation:
         diff = (ifft_pred - ifft_truth).reshape(1, img_size, img_size)
 
         zero = np.isclose((np.zeros((1, img_size, img_size))), diff, atol=1e-3)
-        assert zero.shape == (1, 64, 64)
+        assert zero.shape == (1, img_size, img_size)
 
         num_zero = zero.sum(axis=-1).sum(axis=-1) / (img_size * img_size) * 100
         assert num_zero >= 0

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -405,12 +405,12 @@ class TestEvaluation:
         )
 
         # masks
-        mask_invalid_amp = sampled_gauss_amp < 0
-        mask_invalid_phase = (sampled_gauss_phase <= (-np.pi - 1e-4)) | (
-            sampled_gauss_phase >= (np.pi + 1e-4)
-        )
-        assert mask_invalid_amp.sum() == 0
-        assert mask_invalid_phase.sum() == 0
+        # mask_invalid_amp = sampled_gauss_amp < 0
+        # mask_invalid_phase = (sampled_gauss_phase <= (-np.pi - 1e-4)) | (
+        #   sampled_gauss_phase >= (np.pi + 1e-4)
+        # )
+        # assert mask_invalid_amp.sum() == 0
+        # assert mask_invalid_phase.sum() == 0
 
         sampled_gauss = np.stack([sampled_gauss_amp, sampled_gauss_phase], axis=1)
 
@@ -435,11 +435,14 @@ class TestEvaluation:
         assert results["std"].shape == (num_img, img_size, img_size)
 
     def test_uncertainty_plots(self):
-        from radionets.evaluation.utils import read_pred, sample_images
+        import toml
+        from radionets.evaluation.utils import read_pred, sample_images, read_config
 
+        config = toml.load("./tests/evaluate.toml")
+        conf = read_config(config)
         img = read_pred("./tests/model/predictions_unc.h5")
         results = sample_images(
-            img["pred"][:2, :, :65, :], img["unc"][:2, :, :65, :], 100
+            img["pred"][:2, :, :65, :], img["unc"][:2, :, :65, :], 100, conf
         )
         assert results["mean"].shape == (2, 128, 128)
         assert results["std"].shape == (2, 128, 128)
@@ -472,10 +475,7 @@ def test_trunc_rv(mode, target):
     if mode == "phase":
         a, b = -np.pi, np.pi
     elif mode == "amp":
-        (
-            a,
-            b,
-        ) = (
+        (a, b,) = (
             0,
             np.inf,
         )

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -24,7 +24,12 @@ def test_create_databunch():
 def test_define_learner():
     from radionets.dl_framework.learner import define_learner
     import toml
-    from radionets.dl_training.utils import read_config, define_arch, create_databunch
+    from radionets.dl_training.utils import (
+        read_config,
+        define_arch,
+        create_databunch,
+        get_normalisation_factors,
+    )
 
     config = toml.load("./tests/training.toml")
     train_conf = read_config(config)
@@ -36,7 +41,8 @@ def test_define_learner():
         batch_size=train_conf["batch_size"],
         source_list=train_conf["source_list"],
     )
-
+    norm_factors = get_normalisation_factors(data)
+    train_conf["norm_factors"] = norm_factors
     learn = define_learner(data, arch, train_conf)
 
     assert learn.loss_func is not None

--- a/tests/training.toml
+++ b/tests/training.toml
@@ -21,6 +21,7 @@ norm_path = "none"
 [general]
 fourier = true
 amp_phase = true
+normalize = false
 source_list = false
 arch_name = "SRResNet"
 loss_func = "splitted_L1"

--- a/tests/training.toml
+++ b/tests/training.toml
@@ -21,7 +21,7 @@ norm_path = "none"
 [general]
 fourier = true
 amp_phase = true
-normalize = false
+normalize = "none"
 source_list = false
 arch_name = "SRResNet"
 loss_func = "splitted_L1"


### PR DESCRIPTION
Major changes:
- Add normalization callback with two different techniques
- Update plotting routines for real/imag images
- Update use of ms-ssim
- Update `evaluate_area` and `evaluate_ms_ssim` for half images
- Add `evaluate_ms_ssim` for sampled images

Small changes:
- Add the model name to predictions and sampling file
- Delete unnecessary `pad_unsqueeze` function
- Add `amp_phase` keyword to `sample_images`
- Fix deprecation warning in `sampling.py`
- Add image size to `test_evaluation.py` routines

To-Do

- [x] Add loading of normalization factors
- [x] Add automatic rescaling for evaluation routines