### PR TITLE
Add `isort` pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,9 @@
 repos:
+  - repo: https://github.com/pycqa/isort
+    rev: 5.12.0
+    hooks:
+      - id: isort
+        args: ["--profile", "black", "--filter-files"]
   - repo: https://github.com/psf/black
     rev: 22.6.0
     hooks:


### PR DESCRIPTION
Ripped straight from [ctapipe](https://github.com/cta-observatory/ctapipe/blob/main/.pre-commit-config.yaml), just changing the version because of [this](https://github.com/home-assistant/core/issues/86892).