### PR TITLE
Fix plotting for msssim sampled method

### DIFF
--- a/docs/changes/173.bubugfix.rst
+++ b/docs/changes/173.bubugfix.rst
@@ -1,0 +1,1 @@
+- fix plotting for `evaluate_msssim_sampled`

--- a/radionets/evaluation/train_inspection.py
+++ b/radionets/evaluation/train_inspection.py
@@ -567,7 +567,7 @@ def evaluate_ms_ssim_sampled(conf):
     name_model = Path(model_path).stem
     data_path = str(out_path) + f"/sampled_imgs_{name_model}.h5"
     loader = create_sampled_databunch(data_path, conf["batch_size"])
-    vals = []
+    vals = np.array([])
 
     # iterate trough DataLoader
     for i, (samp, std, img_true) in enumerate(tqdm(loader)):
@@ -578,10 +578,9 @@ def evaluate_ms_ssim_sampled(conf):
             win_size=7,
             size_average=False,
         )
-        vals.extend(val)
+        vals = np.append(vals, val)
 
     click.echo("\nCreating ms-ssim histogram.\n")
-    vals = torch.tensor(vals)
     histogram_ms_ssim(vals, out_path, plot_format=conf["format"])
 
     click.echo(f"\nThe mean ms-ssim value is {vals.mean()}.\n")


### PR DESCRIPTION
Forgot to update the sampled version of the function, it still converts the values to `torch.tensor`, which can not be plotted with the current `histogram_msssim` function.