### PR TITLE
Update symmetry

### DIFF
--- a/docs/changes/200.maintenance.2.rst
+++ b/docs/changes/200.maintenance.2.rst
@@ -1,0 +1,1 @@
+Changed default overlap for Fourier symmetry to 5 px in :func:`radionets.evaluation.utils.apply_symmetry`

--- a/docs/changes/200.maintenance.rst
+++ b/docs/changes/200.maintenance.rst
@@ -1,0 +1,1 @@
+Deleted unused symmetry function in :mod:`radionets.core.model`

--- a/src/radionets/core/model.py
+++ b/src/radionets/core/model.py
@@ -9,7 +9,6 @@ __all__ = [
     "init_cnn",
     "load_pre_model",
     "save_model",
-    "symmetry",
 ]
 
 LOGGER = setup_logger(namespace=__name__)
@@ -101,20 +100,3 @@ def save_model(learn, model_path):
         },
         model_path,
     )
-
-
-def symmetry(x):
-    if x.shape[-1] % 2 != 0:
-        raise ValueError("The symmetry function only works for even image sizes.")
-    upper_half = x[:, :, 0 : x.shape[2] // 2, :].clone()
-    upper_left = upper_half[:, :, :, 0 : upper_half.shape[3] // 2].clone()
-    upper_right = upper_half[:, :, :, upper_half.shape[3] // 2 :].clone()
-    a = torch.flip(upper_left, dims=[-2, -1])
-    b = torch.flip(upper_right, dims=[-2, -1])
-
-    upper_half[:, :, :, 0 : upper_half.shape[3] // 2] = b
-    upper_half[:, :, :, upper_half.shape[3] // 2 :] = a
-
-    x[:, 0, x.shape[2] // 2 :, :] = upper_half[:, 0]
-    x[:, 1, x.shape[2] // 2 :, :] = -upper_half[:, 1]
-    return x

--- a/src/radionets/evaluation/utils.py
+++ b/src/radionets/evaluation/utils.py
@@ -455,7 +455,7 @@ def apply_symmetry(img_dict):
             half_image = img_dict[key].shape[-1] // 2
             output = F.pad(
                 input=img_dict[key],
-                pad=(0, 0, 0, half_image - 1),
+                pad=(0, 0, 0, half_image - 5),
                 mode="constant",
                 value=0,
             )


### PR DESCRIPTION
Update symmetry layer:
- deleted unused symmetry function in `radionets.core.model`
- Changed default symmetry overlap to 5 px in `radionets.evalutation.utils.apply_symmetry`